### PR TITLE
Add webkit-backface-visibility: hidden to the checkbox icon

### DIFF
--- a/src/cljc/ui/element/checkbox.cljc
+++ b/src/cljc/ui/element/checkbox.cljc
@@ -72,6 +72,7 @@
          :transform-origin [[:center :center]]
          :transform        [[(scale 0) (translateX (unit/percent -50)) (translateY (unit/percent -25))]]
          :transition       [[:100ms :ease]]
+         :-webkit-backface-visibility :hidden
          :z-index          2}]
     [:&.indeterminate
      [:i {:transform-origin [[:left :center]]


### PR DESCRIPTION
- Appears to have fixed the weird flickering in the outer container of
checkboxes 👍 
- Really no idea why this has any effect on a 2D transform 😅
- *["This property has no effect on 2D transforms as there is no perspective."](https://developer.mozilla.org/en-US/docs/Web/CSS/backface-visibility)*