### PR TITLE
Remove checkbox icon transition

### DIFF
--- a/src/cljc/ui/element/checkbox.cljc
+++ b/src/cljc/ui/element/checkbox.cljc
@@ -72,7 +72,6 @@
          :font-size        (unit/rem 2.5)
          :transform-origin [[:center :center]]
          :transform        [[(scale 0) (translateX (unit/percent -50)) (translateY (unit/percent -25))]]
-         :transition       [[:100ms :ease]]
          :-webkit-backface-visibility :hidden
          :z-index          2}]
     [:&.indeterminate


### PR DESCRIPTION
- This eliminates any flicker that occurs during state change
- The transition was minimal (100ms) so the difference is not so big
without transition on the icon